### PR TITLE
Fix id generation, wait code and reset

### DIFF
--- a/esphome/components/cc1101/README.md
+++ b/esphome/components/cc1101/README.md
@@ -1,0 +1,1 @@
+Not written by me, meant for testing only. Use this instead: https://github.com/esphome/esphome/pull/6300

--- a/esphome/components/cc1101/__init__.py
+++ b/esphome/components/cc1101/__init__.py
@@ -1,23 +1,20 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome import automation, pins
 from esphome.automation import maybe_simple_id
-from esphome.components import sensor
-from esphome.components import spi
-from esphome.components import remote_base
-from esphome.components import voltage_sampler
+import esphome.codegen as cg
+from esphome.components import remote_base, sensor, spi, voltage_sampler
+import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ID,
-    CONF_FREQUENCY,
-    CONF_PROTOCOL,
     CONF_CODE,
+    CONF_FREQUENCY,
+    CONF_ID,
+    CONF_PROTOCOL,
     CONF_TEMPERATURE,
-    UNIT_EMPTY,
-    UNIT_DECIBEL_MILLIWATT,
-    UNIT_CELSIUS,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_DECIBEL_MILLIWATT,
+    UNIT_EMPTY,
 )
 
 DEPENDENCIES = ["spi"]
@@ -29,7 +26,6 @@ CODEOWNERS = ["@gabest11"]
 CONF_GDO0_PIN = "gdo0_pin"
 CONF_GDO0_ADC_ID = "gdo0_adc_id"
 CONF_BANDWIDTH = "bandwidth"
-# CONF_FREQUENCY = "frequency"
 CONF_RSSI = "rssi"
 CONF_LQI = "lqi"
 CONF_CC1101_ID = "cc1101_id"
@@ -99,7 +95,7 @@ EndTxAction = ns.class_("EndTxAction", automation.Action)
 
 CC1101_ACTION_SCHEMA = maybe_simple_id(
     {
-        cv.Required(CONF_ID): cv.use_id(CC1101),
+        cv.GenerateID(CONF_ID): cv.use_id(CC1101),
     }
 )
 

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -118,6 +118,16 @@ void CC1101::setup() {
 #endif
   }
 
+  // datasheet 19.1.2
+  this->cs_->digital_write(true);
+  delayMicroseconds(1);
+  this->cs_->digital_write(false);
+  delayMicroseconds(1);
+  this->cs_->digital_write(true);
+  delayMicroseconds(41);
+  this->cs_->digital_write(false);
+  delayMicroseconds(5000);
+
   this->spi_setup();
 
   if (!this->reset_()) {
@@ -678,54 +688,31 @@ void CC1101::set_state_(uint8_t state) {
   ESP_LOGV(TAG, "set_state_(0x%02X)", state);
 
   this->trxstate_ = state;
-
-  if (state == CC1101_SRES) {
-    // datasheet 19.1.2
-    // this->disable(); // esp-idf calls end_transaction and asserts, because no begin_transaction was called
-    this->cs_->digital_write(false);
-    delayMicroseconds(5);
-    // this->enable();
-    this->cs_->digital_write(true);
-    delayMicroseconds(10);
-    // this->disable();
-    this->cs_->digital_write(false);
-    delayMicroseconds(41);
-  }
-
   this->strobe_(state);
   this->wait_state_(state);
 }
 
 bool CC1101::wait_state_(uint8_t state) {
-  static constexpr int TIMEOUT_LIMIT = 5000;
-  int timeout = TIMEOUT_LIMIT;
-
-  while (timeout > 0) {
+  uint32_t start = millis();
+  while ((millis() - start) < 1000) {
     uint8_t s = this->read_status_register_(CC1101_MARCSTATE) & 0x1f;
-    if (state == CC1101_SIDLE) {
+    if (state == CC1101_SIDLE || state == CC1101_SRES) {
       if (s == CC1101_MARCSTATE_IDLE)
-        break;
+        return true;
     } else if (state == CC1101_SRX) {
       if (s == CC1101_MARCSTATE_RX || s == CC1101_MARCSTATE_RX_END || s == CC1101_MARCSTATE_RXTX_SWITCH)
-        break;
+        return true;
     } else if (state == CC1101_STX) {
       if (s == CC1101_MARCSTATE_TX || s == CC1101_MARCSTATE_TX_END || s == CC1101_MARCSTATE_TXRX_SWITCH)
-        break;
+        return true;
     } else {
-      break;  // else if TODO
+      return true;  // else if TODO
     }
-
-    timeout--;
-
     delayMicroseconds(1);
   }
-
-  if (timeout < TIMEOUT_LIMIT) {
-    ESP_LOGW(TAG, "wait_state_(0x%02X) timeout = %d/%d", state, timeout, TIMEOUT_LIMIT);
-    delayMicroseconds(100);
-  }
-
-  return timeout > 0;
+  mark_failed();
+  ESP_LOGE(TAG, "CC1101 modem wait state timeout. Check connection.");
+  return false;
 }
 
 void CC1101::split_mdmcfg2_() {


### PR DESCRIPTION
Some fixes:
- Wait code ended up with a watchdog timeout, refactor that.
- Reset code wasnt quite correct, some people had issues, also refactored it. 
- Should use GenerateID instead of Required, dont have to use an id when using actions:
```
remote_transmitter:
  pin: GPIO21
  carrier_duty_percent: 100%
  on_transmit:
    then:
      - cc1101.begin_tx
  on_complete:
    then:
      - cc1101.end_tx
```



